### PR TITLE
Append emr message on error when provided.

### DIFF
--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -341,7 +341,10 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
+    Result = jsx:decode(Body, [return_maps]),
+    Type = maps:get(<<"__type">>, Result),
+    Message = maps:get(<<"message">>, Result, <<"">>),
+    Reason = aws_util:binary_join([Type, <<" ">>, Message], <<"">>),
     {error, Reason, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.


### PR DESCRIPTION
EMR provides a descriptive message for validation errors that turns out to be key for debugging cluster specifications that are well-formed but don't satisfy some (possibly undocumented) constraint. e.g. "Service role and InstanceProfile are required for calls made with temporary credentials provided by STS".