### PR TITLE
better-error-handling

### DIFF
--- a/src/aws_cloud_hsm.erl
+++ b/src/aws_cloud_hsm.erl
@@ -255,7 +255,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_code_commit.erl
+++ b/src/aws_code_commit.erl
@@ -198,7 +198,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_code_deploy.erl
+++ b/src/aws_code_deploy.erl
@@ -431,7 +431,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_code_pipeline.erl
+++ b/src/aws_code_pipeline.erl
@@ -413,7 +413,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_cognito.erl
+++ b/src/aws_cognito.erl
@@ -349,7 +349,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -154,7 +154,7 @@ deliver_config_snapshot(Client, Input, Options)
 %% <code>config:PutEvaluations</code> permission.</li> <li>The rule's AWS
 %% Lambda function has returned <code>NOT_APPLICABLE</code> for all
 %% evaluation results. This can occur if the resources were deleted or
-%% removed from the rule's scope.</li> </ul>
+%% removed from the rule's scope.</li></ul>
 describe_compliance_by_config_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_compliance_by_config_rule(Client, Input, []).
@@ -184,7 +184,7 @@ describe_compliance_by_config_rule(Client, Input, Options)
 %% <code>config:PutEvaluations</code> permission.</li> <li>The rule's AWS
 %% Lambda function has returned <code>NOT_APPLICABLE</code> for all
 %% evaluation results. This can occur if the resources were deleted or
-%% removed from the rule's scope.</li> </ul>
+%% removed from the rule's scope.</li></ul>
 describe_compliance_by_resource(Client, Input)
   when is_map(Client), is_map(Input) ->
     describe_compliance_by_resource(Client, Input, []).
@@ -392,6 +392,8 @@ list_discovered_resources(Client, Input, Options)
 %% href="http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html">Evaluating
 %% AWS Resource Configurations with AWS Config</a> in the <i>AWS Config
 %% Developer Guide</i>.
+%%
+%% <p/>
 put_config_rule(Client, Input)
   when is_map(Client), is_map(Input) ->
     put_config_rule(Client, Input, []).

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -34,10 +34,20 @@
 %% Is AWS Config?</a> in the <i>AWS Config Developer Guide</i>.
 -module(aws_config).
 
--export([delete_delivery_channel/2,
+-export([delete_config_rule/2,
+         delete_config_rule/3,
+         delete_delivery_channel/2,
          delete_delivery_channel/3,
          deliver_config_snapshot/2,
          deliver_config_snapshot/3,
+         describe_compliance_by_config_rule/2,
+         describe_compliance_by_config_rule/3,
+         describe_compliance_by_resource/2,
+         describe_compliance_by_resource/3,
+         describe_config_rule_evaluation_status/2,
+         describe_config_rule_evaluation_status/3,
+         describe_config_rules/2,
+         describe_config_rules/3,
          describe_configuration_recorder_status/2,
          describe_configuration_recorder_status/3,
          describe_configuration_recorders/2,
@@ -46,12 +56,26 @@
          describe_delivery_channel_status/3,
          describe_delivery_channels/2,
          describe_delivery_channels/3,
+         get_compliance_details_by_config_rule/2,
+         get_compliance_details_by_config_rule/3,
+         get_compliance_details_by_resource/2,
+         get_compliance_details_by_resource/3,
+         get_compliance_summary_by_config_rule/2,
+         get_compliance_summary_by_config_rule/3,
+         get_compliance_summary_by_resource_type/2,
+         get_compliance_summary_by_resource_type/3,
          get_resource_config_history/2,
          get_resource_config_history/3,
+         list_discovered_resources/2,
+         list_discovered_resources/3,
+         put_config_rule/2,
+         put_config_rule/3,
          put_configuration_recorder/2,
          put_configuration_recorder/3,
          put_delivery_channel/2,
          put_delivery_channel/3,
+         put_evaluations/2,
+         put_evaluations/3,
          start_configuration_recorder/2,
          start_configuration_recorder/3,
          stop_configuration_recorder/2,
@@ -62,6 +86,23 @@
 %%====================================================================
 %% API
 %%====================================================================
+
+%% @doc Deletes the specified AWS Config rule and all of its evaluation
+%% results.
+%%
+%% AWS Config sets the state of a rule to <code>DELETING</code> until the
+%% deletion is complete. You cannot update a rule while it is in this state.
+%% If you make a <code>PutConfigRule</code> request for the rule, you will
+%% receive a <code>ResourceInUseException</code>.
+%%
+%% You can check the state of a rule by using the
+%% <code>DescribeConfigRules</code> request.
+delete_config_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_config_rule(Client, Input, []).
+delete_config_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteConfigRule">>, Input, Options).
 
 %% @doc Deletes the specified delivery channel.
 %%
@@ -91,6 +132,84 @@ deliver_config_snapshot(Client, Input)
 deliver_config_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeliverConfigSnapshot">>, Input, Options).
+
+%% @doc Indicates whether the specified AWS Config rules are compliant. If a
+%% rule is noncompliant, this action returns the number of AWS resources that
+%% do not comply with the rule.
+%%
+%% A rule is compliant if all of the evaluated resources comply with it, and
+%% it is noncompliant if any of these resources do not comply.
+%%
+%% If AWS Config has no current evaluation results for the rule, it returns
+%% <code>InsufficientData</code>. This result might indicate one of the
+%% following conditions: <ul> <li>AWS Config has never invoked an evaluation
+%% for the rule. To check whether it has, use the
+%% <code>DescribeConfigRuleEvaluationStatus</code> action to get the
+%% <code>LastSuccessfulInvocationTime</code> and
+%% <code>LastFailedInvocationTime</code>.</li> <li>The rule's AWS Lambda
+%% function is failing to send evaluation results to AWS Config. Verify that
+%% the role that you assigned to your configuration recorder includes the
+%% <code>config:PutEvaluations</code> permission. If the rule is a customer
+%% managed rule, verify that the AWS Lambda execution role includes the
+%% <code>config:PutEvaluations</code> permission.</li> <li>The rule's AWS
+%% Lambda function has returned <code>NOT_APPLICABLE</code> for all
+%% evaluation results. This can occur if the resources were deleted or
+%% removed from the rule's scope.</li> </ul>
+describe_compliance_by_config_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_compliance_by_config_rule(Client, Input, []).
+describe_compliance_by_config_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeComplianceByConfigRule">>, Input, Options).
+
+%% @doc Indicates whether the specified AWS resources are compliant. If a
+%% resource is noncompliant, this action returns the number of AWS Config
+%% rules that the resource does not comply with.
+%%
+%% A resource is compliant if it complies with all the AWS Config rules that
+%% evaluate it. It is noncompliant if it does not comply with one or more of
+%% these rules.
+%%
+%% If AWS Config has no current evaluation results for the resource, it
+%% returns <code>InsufficientData</code>. This result might indicate one of
+%% the following conditions about the rules that evaluate the resource: <ul>
+%% <li>AWS Config has never invoked an evaluation for the rule. To check
+%% whether it has, use the <code>DescribeConfigRuleEvaluationStatus</code>
+%% action to get the <code>LastSuccessfulInvocationTime</code> and
+%% <code>LastFailedInvocationTime</code>.</li> <li>The rule's AWS Lambda
+%% function is failing to send evaluation results to AWS Config. Verify that
+%% the role that you assigned to your configuration recorder includes the
+%% <code>config:PutEvaluations</code> permission. If the rule is a customer
+%% managed rule, verify that the AWS Lambda execution role includes the
+%% <code>config:PutEvaluations</code> permission.</li> <li>The rule's AWS
+%% Lambda function has returned <code>NOT_APPLICABLE</code> for all
+%% evaluation results. This can occur if the resources were deleted or
+%% removed from the rule's scope.</li> </ul>
+describe_compliance_by_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_compliance_by_resource(Client, Input, []).
+describe_compliance_by_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeComplianceByResource">>, Input, Options).
+
+%% @doc Returns status information for each of your AWS managed Config rules.
+%% The status includes information such as the last time AWS Config invoked
+%% the rule, the last time AWS Config failed to invoke the rule, and the
+%% related error for the last failure.
+describe_config_rule_evaluation_status(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_config_rule_evaluation_status(Client, Input, []).
+describe_config_rule_evaluation_status(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeConfigRuleEvaluationStatus">>, Input, Options).
+
+%% @doc Returns details about your AWS Config rules.
+describe_config_rules(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_config_rules(Client, Input, []).
+describe_config_rules(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeConfigRules">>, Input, Options).
 
 %% @doc Returns the current status of the specified configuration recorder.
 %% If a configuration recorder is not specified, this action returns the
@@ -147,17 +266,62 @@ describe_delivery_channels(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeDeliveryChannels">>, Input, Options).
 
+%% @doc Returns the evaluation results for the specified AWS Config rule. The
+%% results indicate which AWS resources were evaluated by the rule, when each
+%% resource was last evaluated, and whether each resource complies with the
+%% rule.
+get_compliance_details_by_config_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_compliance_details_by_config_rule(Client, Input, []).
+get_compliance_details_by_config_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetComplianceDetailsByConfigRule">>, Input, Options).
+
+%% @doc Returns the evaluation results for the specified AWS resource. The
+%% results indicate which AWS Config rules were used to evaluate the
+%% resource, when each rule was last used, and whether the resource complies
+%% with each rule.
+get_compliance_details_by_resource(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_compliance_details_by_resource(Client, Input, []).
+get_compliance_details_by_resource(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetComplianceDetailsByResource">>, Input, Options).
+
+%% @doc Returns the number of AWS Config rules that are compliant and
+%% noncompliant, up to a maximum of 25 for each.
+get_compliance_summary_by_config_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_compliance_summary_by_config_rule(Client, Input, []).
+get_compliance_summary_by_config_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetComplianceSummaryByConfigRule">>, Input, Options).
+
+%% @doc Returns the number of resources that are compliant and the number
+%% that are noncompliant. You can specify one or more resource types to get
+%% these numbers for each resource type. The maximum number returned is 100.
+get_compliance_summary_by_resource_type(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    get_compliance_summary_by_resource_type(Client, Input, []).
+get_compliance_summary_by_resource_type(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"GetComplianceSummaryByResourceType">>, Input, Options).
+
 %% @doc Returns a list of configuration items for the specified resource. The
 %% list contains details about each state of the resource during the
-%% specified time interval. You can specify a <code>limit</code> on the
-%% number of results returned on the page. If a limit is specified, a
-%% <code>nextToken</code> is returned as part of the result that you can use
-%% to continue this request.
+%% specified time interval.
+%%
+%% The response is paginated, and by default, AWS Config returns a limit of
+%% 10 configuration items per page. You can customize this number with the
+%% <code>limit</code> parameter. The response includes a
+%% <code>nextToken</code> string, and to get the next page of results, run
+%% the request again and enter this string for the <code>nextToken</code>
+%% parameter.
 %%
 %% <note> Each call to the API is limited to span a duration of seven days.
 %% It is likely that the number of records returned is smaller than the
 %% specified <code>limit</code>. In such cases, you can make another call,
-%% using the <code>nextToken</code> .
+%% using the <code>nextToken</code>.
 %%
 %% </note>
 get_resource_config_history(Client, Input)
@@ -166,6 +330,74 @@ get_resource_config_history(Client, Input)
 get_resource_config_history(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"GetResourceConfigHistory">>, Input, Options).
+
+%% @doc Accepts a resource type and returns a list of resource identifiers
+%% for the resources of that type. A resource identifier includes the
+%% resource type, ID, and (if available) the custom resource name. The
+%% results consist of resources that AWS Config has discovered, including
+%% those that AWS Config is not currently recording. You can narrow the
+%% results to include only resources that have specific resource IDs or a
+%% resource name.
+%%
+%% <note>You can specify either resource IDs or a resource name but not both
+%% in the same request.</note> The response is paginated, and by default AWS
+%% Config lists 100 resource identifiers on each page. You can customize this
+%% number with the <code>limit</code> parameter. The response includes a
+%% <code>nextToken</code> string, and to get the next page of results, run
+%% the request again and enter this string for the <code>nextToken</code>
+%% parameter.
+list_discovered_resources(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    list_discovered_resources(Client, Input, []).
+list_discovered_resources(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"ListDiscoveredResources">>, Input, Options).
+
+%% @doc Adds or updates an AWS Config rule for evaluating whether your AWS
+%% resources comply with your desired configurations.
+%%
+%% You can use this action for customer managed Config rules and AWS managed
+%% Config rules. A customer managed Config rule is a custom rule that you
+%% develop and maintain. An AWS managed Config rule is a customizable,
+%% predefined rule that is provided by AWS Config.
+%%
+%% If you are adding a new customer managed Config rule, you must first
+%% create the AWS Lambda function that the rule invokes to evaluate your
+%% resources. When you use the <code>PutConfigRule</code> action to add the
+%% rule to AWS Config, you must specify the Amazon Resource Name (ARN) that
+%% AWS Lambda assigns to the function. Specify the ARN for the
+%% <code>SourceIdentifier</code> key. This key is part of the
+%% <code>Source</code> object, which is part of the <code>ConfigRule</code>
+%% object.
+%%
+%% If you are adding a new AWS managed Config rule, specify the rule's
+%% identifier for the <code>SourceIdentifier</code> key. To reference AWS
+%% managed Config rule identifiers, see <a
+%% href="http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_use-managed-rules.html">Using
+%% AWS Managed Config Rules</a>.
+%%
+%% For any new rule that you add, specify the <code>ConfigRuleName</code> in
+%% the <code>ConfigRule</code> object. Do not specify the
+%% <code>ConfigRuleArn</code> or the <code>ConfigRuleId</code>. These values
+%% are generated by AWS Config for new rules.
+%%
+%% If you are updating a rule that you have added previously, specify the
+%% rule's <code>ConfigRuleName</code>, <code>ConfigRuleId</code>, or
+%% <code>ConfigRuleArn</code> in the <code>ConfigRule</code> data type that
+%% you use in this request.
+%%
+%% The maximum number of rules that AWS Config supports is 25.
+%%
+%% For more information about developing and using AWS Config rules, see <a
+%% href="http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config.html">Evaluating
+%% AWS Resource Configurations with AWS Config</a> in the <i>AWS Config
+%% Developer Guide</i>.
+put_config_rule(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_config_rule(Client, Input, []).
+put_config_rule(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutConfigRule">>, Input, Options).
 
 %% @doc Creates a new configuration recorder to record the selected resource
 %% configurations.
@@ -208,6 +440,16 @@ put_delivery_channel(Client, Input)
 put_delivery_channel(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"PutDeliveryChannel">>, Input, Options).
+
+%% @doc Used by an AWS Lambda function to deliver evaluation results to AWS
+%% Config. This action is required in every AWS Lambda function that is
+%% invoked by an AWS Config rule.
+put_evaluations(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    put_evaluations(Client, Input, []).
+put_evaluations(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"PutEvaluations">>, Input, Options).
 
 %% @doc Starts recording configurations of the AWS resources you have
 %% selected to record in your AWS account.
@@ -256,7 +498,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_data_pipeline.erl
+++ b/src/aws_data_pipeline.erl
@@ -342,7 +342,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_direct_connect.erl
+++ b/src/aws_direct_connect.erl
@@ -347,7 +347,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_directory_service.erl
+++ b/src/aws_directory_service.erl
@@ -16,16 +16,24 @@
          create_computer/3,
          create_directory/2,
          create_directory/3,
+         create_microsoft_a_d/2,
+         create_microsoft_a_d/3,
          create_snapshot/2,
          create_snapshot/3,
+         create_trust/2,
+         create_trust/3,
          delete_directory/2,
          delete_directory/3,
          delete_snapshot/2,
          delete_snapshot/3,
+         delete_trust/2,
+         delete_trust/3,
          describe_directories/2,
          describe_directories/3,
          describe_snapshots/2,
          describe_snapshots/3,
+         describe_trusts/2,
+         describe_trusts/3,
          disable_radius/2,
          disable_radius/3,
          disable_sso/2,
@@ -41,7 +49,9 @@
          restore_from_snapshot/2,
          restore_from_snapshot/3,
          update_radius/2,
-         update_radius/3]).
+         update_radius/3,
+         verify_trust/2,
+         verify_trust/3]).
 
 -include_lib("hackney/include/hackney_lib.hrl").
 
@@ -49,7 +59,7 @@
 %% API
 %%====================================================================
 
-%% @doc Creates an AD Connector to connect an on-premises directory.
+%% @doc Creates an AD Connector to connect to an on-premises directory.
 connect_directory(Client, Input)
   when is_map(Client), is_map(Input) ->
     connect_directory(Client, Input, []).
@@ -59,7 +69,8 @@ connect_directory(Client, Input, Options)
 
 %% @doc Creates an alias for a directory and assigns the alias to the
 %% directory. The alias is used to construct the access URL for the
-%% directory, such as <code>http://&#x3C;alias&#x3E;.awsapps.com</code>.
+%% directory, such as
+%% <code>http://<![CDATA[&#x3C;]]>alias<![CDATA[&#x3E;]]>.awsapps.com</code>.
 %%
 %% <important> After an alias has been created, it cannot be deleted or
 %% reused, so this operation should only be used when absolutely necessary.
@@ -89,15 +100,41 @@ create_directory(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateDirectory">>, Input, Options).
 
-%% @doc Creates a snapshot of an existing directory.
+%% @doc Creates a Microsoft AD in the AWS cloud.
+create_microsoft_a_d(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_microsoft_a_d(Client, Input, []).
+create_microsoft_a_d(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateMicrosoftAD">>, Input, Options).
+
+%% @doc Creates a snapshot of a Simple AD directory.
 %%
-%% You cannot take snapshots of extended or connected directories.
+%% <note> You cannot take snapshots of AD Connector directories.
+%%
+%% </note>
 create_snapshot(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_snapshot(Client, Input, []).
 create_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"CreateSnapshot">>, Input, Options).
+
+%% @doc AWS Directory Service for Microsoft Active Directory allows you to
+%% configure trust relationships. For example, you can establish a trust
+%% between your Microsoft AD in the AWS cloud, and your existing on-premises
+%% Microsoft Active Directory. This would allow you to provide users and
+%% groups access to resources in either domain, with a single set of
+%% credentials.
+%%
+%% This action initiates the creation of the AWS side of a trust relationship
+%% between a Microsoft AD in the AWS cloud and an external domain.
+create_trust(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    create_trust(Client, Input, []).
+create_trust(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"CreateTrust">>, Input, Options).
 
 %% @doc Deletes an AWS Directory Service directory.
 delete_directory(Client, Input)
@@ -114,6 +151,15 @@ delete_snapshot(Client, Input)
 delete_snapshot(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteSnapshot">>, Input, Options).
+
+%% @doc Deletes an existing trust relationship between your Microsoft AD in
+%% the AWS cloud and an external domain.
+delete_trust(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    delete_trust(Client, Input, []).
+delete_trust(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DeleteTrust">>, Input, Options).
 
 %% @doc Obtains information about the directories that belong to this
 %% account.
@@ -155,8 +201,20 @@ describe_snapshots(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DescribeSnapshots">>, Input, Options).
 
-%% @doc Disables multi-factor authentication (MFA) with Remote Authentication
-%% Dial In User Service (RADIUS) for an AD Connector directory.
+%% @doc Obtains information about the trust relationships for this account.
+%%
+%% If no input parameters are provided, such as DirectoryId or TrustIds, this
+%% request describes all the trust relationships belonging to the account.
+describe_trusts(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    describe_trusts(Client, Input, []).
+describe_trusts(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"DescribeTrusts">>, Input, Options).
+
+%% @doc Disables multi-factor authentication (MFA) with the Remote
+%% Authentication Dial In User Service (RADIUS) server for an AD Connector
+%% directory.
 disable_radius(Client, Input)
   when is_map(Client), is_map(Input) ->
     disable_radius(Client, Input, []).
@@ -172,8 +230,9 @@ disable_sso(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DisableSso">>, Input, Options).
 
-%% @doc Enables multi-factor authentication (MFA) with Remote Authentication
-%% Dial In User Service (RADIUS) for an AD Connector directory.
+%% @doc Enables multi-factor authentication (MFA) with the Remote
+%% Authentication Dial In User Service (RADIUS) server for an AD Connector
+%% directory.
 enable_radius(Client, Input)
   when is_map(Client), is_map(Input) ->
     enable_radius(Client, Input, []).
@@ -230,6 +289,18 @@ update_radius(Client, Input)
 update_radius(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"UpdateRadius">>, Input, Options).
+
+%% @doc AWS Directory Service for Microsoft Active Directory allows you to
+%% configure and verify trust relationships.
+%%
+%% This action verifies a trust relationship between your Microsoft AD in the
+%% AWS cloud and an external domain.
+verify_trust(Client, Input)
+  when is_map(Client), is_map(Input) ->
+    verify_trust(Client, Input, []).
+verify_trust(Client, Input, Options)
+  when is_map(Client), is_map(Input), is_list(Options) ->
+    request(Client, <<"VerifyTrust">>, Input, Options).
 
 %%====================================================================
 %% Internal functions

--- a/src/aws_directory_service.erl
+++ b/src/aws_directory_service.erl
@@ -257,7 +257,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_dynamodb.erl
+++ b/src/aws_dynamodb.erl
@@ -594,7 +594,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_dynamodb_streams.erl
+++ b/src/aws_dynamodb_streams.erl
@@ -153,7 +153,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -91,7 +91,28 @@ create_cluster(Client, Input, Options)
 %% @doc Runs and maintains a desired number of tasks from a specified task
 %% definition. If the number of tasks running in a service drops below
 %% <code>desiredCount</code>, Amazon ECS spawns another instantiation of the
-%% task in the specified cluster.
+%% task in the specified cluster. To update an existing service, see
+%% <a>UpdateService</a>.
+%%
+%% When the service scheduler launches new tasks, it attempts to balance them
+%% across the Availability Zones in your cluster with the following logic:
+%%
+%% <ul> <li> Determine which of the container instances in your cluster can
+%% support your service's task definition (for example, they have the
+%% required CPU, memory, ports, and container instance attributes).
+%%
+%% </li> <li> Sort the valid container instances by the fewest number of
+%% running tasks for this service in the same Availability Zone as the
+%% instance. For example, if zone A has one running service task and zones B
+%% and C each have zero, valid container instances in either zone B or C are
+%% considered optimal for placement.
+%%
+%% </li> <li> Place the new service task on a valid container instance in an
+%% optimal Availability Zone (based on the previous steps), favoring
+%% container instances with the fewest number of running tasks for this
+%% service.
+%%
+%% </li> </ul>
 create_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_service(Client, Input, []).
@@ -110,7 +131,25 @@ delete_cluster(Client, Input, Options)
   when is_map(Client), is_map(Input), is_list(Options) ->
     request(Client, <<"DeleteCluster">>, Input, Options).
 
-%% @doc Deletes a specified service within a cluster.
+%% @doc Deletes a specified service within a cluster. You can delete a
+%% service if you have no running tasks in it and the desired task count is
+%% zero. If the service is actively maintaining tasks, you cannot delete it,
+%% and you must update the service to a desired task count of zero. For more
+%% information, see <a>UpdateService</a>.
+%%
+%% <note> When you delete a service, if there are still running tasks that
+%% require cleanup, the service status moves from <code>ACTIVE</code> to
+%% <code>DRAINING</code>, and the service is no longer visible in the console
+%% or in <a>ListServices</a> API operations. After the tasks have stopped,
+%% then the service status moves from <code>DRAINING</code> to
+%% <code>INACTIVE</code>. Services in the <code>DRAINING</code> or
+%% <code>INACTIVE</code> status can still be viewed with
+%% <a>DescribeServices</a> API operations; however, in the future,
+%% <code>INACTIVE</code> services may be cleaned up and purged from Amazon
+%% ECS record keeping, and <a>DescribeServices</a> API operations on those
+%% services will return a <code>ServiceNotFoundException</code> error.
+%%
+%% </note>
 delete_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     delete_service(Client, Input, []).
@@ -418,6 +457,26 @@ update_container_agent(Client, Input, Options)
 %% stopped. If the container handles the <code>SIGTERM</code> gracefully and
 %% exits within 30 seconds from receiving it, no <code>SIGKILL</code> is
 %% sent.
+%%
+%% When the service scheduler launches new tasks, it attempts to balance them
+%% across the Availability Zones in your cluster with the following logic:
+%%
+%% <ul> <li> Determine which of the container instances in your cluster can
+%% support your service's task definition (for example, they have the
+%% required CPU, memory, ports, and container instance attributes).
+%%
+%% </li> <li> Sort the valid container instances by the fewest number of
+%% running tasks for this service in the same Availability Zone as the
+%% instance. For example, if zone A has one running service task and zones B
+%% and C each have zero, valid container instances in either zone B or C are
+%% considered optimal for placement.
+%%
+%% </li> <li> Place the new service task on a valid container instance in an
+%% optimal Availability Zone (based on the previous steps), favoring
+%% container instances with the fewest number of running tasks for this
+%% service.
+%%
+%% </li> </ul>
 update_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_service(Client, Input, []).

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -1,12 +1,10 @@
 %% WARNING: DO NOT EDIT, AUTO-GENERATED CODE!
 %% See https://github.com/jkakar/aws-codegen for more details.
 
-%% @doc
-%%
-%% Amazon EC2 Container Service (Amazon ECS) is a highly scalable, fast,
+%% @doc Amazon EC2 Container Service (Amazon ECS) is a highly scalable, fast,
 %% container management service that makes it easy to run, stop, and manage
-%% Docker containers on a cluster of Amazon EC2 instances. Amazon ECS lets
-%% you launch and stop container-enabled applications with simple API calls,
+%% Docker containers on a cluster of EC2 instances. Amazon ECS lets you
+%% launch and stop container-enabled applications with simple API calls,
 %% allows you to get the state of your cluster from a centralized service,
 %% and gives you access to many familiar Amazon EC2 features like security
 %% groups, Amazon EBS volumes, and IAM roles.
@@ -79,10 +77,10 @@
 %% API
 %%====================================================================
 
-%% @doc Creates a new Amazon ECS cluster. By default, your account will
-%% receive a <code>default</code> cluster when you launch your first
-%% container instance. However, you can create your own cluster with a unique
-%% name with the <code>CreateCluster</code> action.
+%% @doc Creates a new Amazon ECS cluster. By default, your account receives a
+%% <code>default</code> cluster when you launch your first container
+%% instance. However, you can create your own cluster with a unique name with
+%% the <code>CreateCluster</code> action.
 create_cluster(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_cluster(Client, Input, []).
@@ -92,8 +90,8 @@ create_cluster(Client, Input, Options)
 
 %% @doc Runs and maintains a desired number of tasks from a specified task
 %% definition. If the number of tasks running in a service drops below
-%% <code>desiredCount</code>, Amazon ECS will spawn another instantiation of
-%% the task in the specified cluster.
+%% <code>desiredCount</code>, Amazon ECS spawns another instantiation of the
+%% task in the specified cluster.
 create_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     create_service(Client, Input, []).
@@ -121,7 +119,7 @@ delete_service(Client, Input, Options)
     request(Client, <<"DeleteService">>, Input, Options).
 
 %% @doc Deregisters an Amazon ECS container instance from the specified
-%% cluster. This instance will no longer be available to run tasks.
+%% cluster. This instance is no longer available to run tasks.
 %%
 %% If you intend to use the container instance for some other purpose after
 %% deregistration, you should stop all of the tasks running on the container
@@ -190,7 +188,7 @@ describe_services(Client, Input, Options)
     request(Client, <<"DescribeServices">>, Input, Options).
 
 %% @doc Describes a task definition. You can specify a <code>family</code>
-%% and <code>revision</code> to find information on a specific task
+%% and <code>revision</code> to find information about a specific task
 %% definition, or you can simply specify the family to find the latest
 %% <code>ACTIVE</code> revision in that family.
 %%
@@ -285,8 +283,8 @@ list_tasks(Client, Input, Options)
 %% @doc <note>This action is only used by the Amazon EC2 Container Service
 %% agent, and it is not intended for use outside of the agent.
 %%
-%% </note> Registers an Amazon EC2 instance into the specified cluster. This
-%% instance will become available to place containers on.
+%% </note> Registers an EC2 instance into the specified cluster. This
+%% instance becomes available to place containers on.
 register_container_instance(Client, Input)
   when is_map(Client), is_map(Input) ->
     register_container_instance(Client, Input, []).
@@ -297,7 +295,7 @@ register_container_instance(Client, Input, Options)
 %% @doc Registers a new task definition from the supplied <code>family</code>
 %% and <code>containerDefinitions</code>. Optionally, you can add data
 %% volumes to your containers with the <code>volumes</code> parameter. For
-%% more information on task definition parameters and defaults, see <a
+%% more information about task definition parameters and defaults, see <a
 %% href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html">Amazon
 %% ECS Task Definitions</a> in the <i>Amazon EC2 Container Service Developer
 %% Guide</i>.
@@ -309,8 +307,8 @@ register_task_definition(Client, Input, Options)
     request(Client, <<"RegisterTaskDefinition">>, Input, Options).
 
 %% @doc Start a task using random placement and the default Amazon ECS
-%% scheduler. If you want to use your own scheduler or place a task on a
-%% specific container instance, use <code>StartTask</code> instead.
+%% scheduler. To use your own scheduler or place a task on a specific
+%% container instance, use <code>StartTask</code> instead.
 %%
 %% <important> The <code>count</code> parameter is limited to 10 tasks per
 %% call.
@@ -324,8 +322,8 @@ run_task(Client, Input, Options)
     request(Client, <<"RunTask">>, Input, Options).
 
 %% @doc Starts a new task from the specified task definition on the specified
-%% container instance or instances. If you want to use the default Amazon ECS
-%% scheduler to place your task, use <code>RunTask</code> instead.
+%% container instance or instances. To use the default Amazon ECS scheduler
+%% to place your task, use <code>RunTask</code> instead.
 %%
 %% <important> The list of container instances to start tasks on is limited
 %% to 10.
@@ -339,6 +337,13 @@ start_task(Client, Input, Options)
     request(Client, <<"StartTask">>, Input, Options).
 
 %% @doc Stops a running task.
+%%
+%% When <a>StopTask</a> is called on a task, the equivalent of <code>docker
+%% stop</code> is issued to the containers running in the task. This results
+%% in a <code>SIGTERM</code> and a 30-second timeout, after which
+%% <code>SIGKILL</code> is sent and the containers are forcibly stopped. If
+%% the container handles the <code>SIGTERM</code> gracefully and exits within
+%% 30 seconds from receiving it, no <code>SIGKILL</code> is sent.
 stop_task(Client, Input)
   when is_map(Client), is_map(Input) ->
     stop_task(Client, Input, []).
@@ -405,6 +410,14 @@ update_container_agent(Client, Input, Options)
 %% when <code>UpdateService</code> is run. If your cluster cannot support
 %% another instantiation of the task used in your service, you can reduce the
 %% desired count of your service by one before modifying the task definition.
+%%
+%% When <a>UpdateService</a> replaces a task during an update, the equivalent
+%% of <code>docker stop</code> is issued to the containers running in the
+%% task. This results in a <code>SIGTERM</code> and a 30-second timeout,
+%% after which <code>SIGKILL</code> is sent and the containers are forcibly
+%% stopped. If the container handles the <code>SIGTERM</code> gracefully and
+%% exits within 30 seconds from receiving it, no <code>SIGKILL</code> is
+%% sent.
 update_service(Client, Input)
   when is_map(Client), is_map(Input) ->
     update_service(Client, Input, []).
@@ -438,7 +451,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -341,7 +341,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_ops_works.erl
+++ b/src/aws_ops_works.erl
@@ -1421,7 +1421,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_route53_domains.erl
+++ b/src/aws_route53_domains.erl
@@ -332,7 +332,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_support.erl
+++ b/src/aws_support.erl
@@ -371,7 +371,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_swf.erl
+++ b/src/aws_swf.erl
@@ -1156,7 +1156,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.

--- a/src/aws_workspaces.erl
+++ b/src/aws_workspaces.erl
@@ -184,7 +184,8 @@ handle_response({ok, 200, ResponseHeaders, Client}) ->
     {ok, Result, {200, ResponseHeaders, Client}};
 handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {ok, Body} = hackney:body(Client),
-    Reason = maps:get(<<"__type">>, jsx:decode(Body, [return_maps])),
-    {error, Reason, {StatusCode, ResponseHeaders, Client}};
+    #{<<"__type">> := Exception,
+      <<"message">> := Reason} = jsx:decode(Body, [return_maps]),
+    {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.


### PR DESCRIPTION
Break backwards compatibility by changing the result returned by
client functions to break the error out into a `{Exception, Reason}`
tuple instead of the bare `Exception` value that was returned
previously.  Also, update clients to use the latest API
specifications.