### PR TITLE
Add support for a temporary client

### DIFF
--- a/src/aws_client.erl
+++ b/src/aws_client.erl
@@ -1,11 +1,13 @@
 -module(aws_client).
 
--export([make_client/3, make_temporary_client/4]).
+-export([make_client/3, make_temporary_client/4,
+	 make_local_client/3]).
 
 -type access_key_id() :: binary().
 -type secret_access_key() :: binary().
 -type region() :: binary().
 -type token() :: binary().
+-type http_port() :: binary().
 -type aws_client() :: map().
 -export_type([access_key_id/0, secret_access_key/0, region/0,
               token/0, aws_client/0]).
@@ -22,6 +24,8 @@ make_client(AccessKeyID, SecretAccessKey, Region)
       secret_access_key => SecretAccessKey,
       region => Region,
       endpoint => <<"amazonaws.com">>,
+      proto => <<"https">>,
+      port => <<"443">>,
       service => undefined}.
 
 -spec make_temporary_client(access_key_id(), secret_access_key(), token(), region()) ->
@@ -34,6 +38,19 @@ make_temporary_client(AccessKeyID, SecretAccessKey, Token, Region)
       token => Token,
       region => Region,
       endpoint => <<"amazonaws.com">>,
+      proto => <<"https">>,
+      port => <<"443">>,
+      service => undefined}.
+
+-spec make_local_client(access_key_id(), secret_access_key(), http_port()) ->
+			       aws_client().
+make_local_client(AccessKeyID, SecretAccessKey, Port)
+  when is_binary(AccessKeyID), is_binary(SecretAccessKey), is_binary(Port) ->
+    #{access_key_id => AccessKeyID,
+      secret_access_key => SecretAccessKey,
+      region => <<"local">>,
+      proto => <<"http">>,
+      port => Port,
       service => undefined}.
 
 %%====================================================================

--- a/src/aws_client.erl
+++ b/src/aws_client.erl
@@ -63,22 +63,38 @@ make_local_client(AccessKeyID, SecretAccessKey, Port)
 %% make_client/0 returns a clienturation map with default values.
 make_client_test() ->
     ?assertEqual(#{access_key_id => <<"access-key-id">>,
-                   secret_access_key => <<"secret-access-key">>,
-                   region => <<"region">>,
                    endpoint => <<"amazonaws.com">>,
+                   port => <<"443">>,
+                   proto => <<"https">>,
+                   region => <<"region">>,
+                   secret_access_key => <<"secret-access-key">>,
                    service => undefined},
                  make_client(<<"access-key-id">>, <<"secret-access-key">>,
                              <<"region">>)).
 
 make_temporary_client_test() ->
     ?assertEqual(#{access_key_id => <<"access-key-id">>,
-                   secret_access_key => <<"secret-access-key">>,
-                   token => <<"some-token">>,
-                   region => <<"region">>,
                    endpoint => <<"amazonaws.com">>,
-                   service => undefined},
+                   port => <<"443">>,
+                   proto => <<"https">>,
+                   region => <<"region">>,
+                   secret_access_key => <<"secret-access-key">>,
+                   service => undefined,
+                   token => <<"some-token">>},
                  make_temporary_client(<<"access-key-id">>,
                                        <<"secret-access-key">>,
                                        <<"some-token">>,
                                        <<"region">>)).
+
+make_local_client_test() ->
+    ?assertEqual(#{access_key_id => <<"access-key-id">>,
+		   port => <<"8000">>,
+		   proto => <<"http">>,
+		   region => <<"local">>,
+		   secret_access_key => <<"secret-access-key">>,
+		   service => undefined},
+		 make_local_client(<<"access-key-id">>,
+				   <<"secret-access-key">>,
+				   <<"8000">>)).
+
 -endif.

--- a/src/aws_cloud_hsm.erl
+++ b/src/aws_cloud_hsm.erl
@@ -241,7 +241,7 @@ modify_luna_client(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"cloudhsm">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"cloudhsm">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -267,10 +267,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_cloud_hsm.erl
+++ b/src/aws_cloud_hsm.erl
@@ -241,12 +241,8 @@ modify_luna_client(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"cloudhsm">>},
-    Host = aws_util:binary_join([<<"cloudhsm.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"CloudHsmFrontendService.">>/binary, Action/binary>>}],
@@ -270,3 +266,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_cloud_trail.erl
+++ b/src/aws_cloud_trail.erl
@@ -220,12 +220,8 @@ update_trail(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"cloudtrail">>},
-    Host = aws_util:binary_join([<<"cloudtrail.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.">>/binary, Action/binary>>}],
@@ -249,3 +245,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_cloud_trail.erl
+++ b/src/aws_cloud_trail.erl
@@ -220,7 +220,7 @@ update_trail(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"cloudtrail">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"cloudtrail">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -246,10 +246,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_code_commit.erl
+++ b/src/aws_code_commit.erl
@@ -184,7 +184,7 @@ update_repository_name(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"codecommit">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"codecommit">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -210,10 +210,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_code_commit.erl
+++ b/src/aws_code_commit.erl
@@ -184,12 +184,8 @@ update_repository_name(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"codecommit">>},
-    Host = aws_util:binary_join([<<"codecommit.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"CodeCommit_20150413.">>/binary, Action/binary>>}],
@@ -213,3 +209,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_code_deploy.erl
+++ b/src/aws_code_deploy.erl
@@ -417,7 +417,7 @@ update_deployment_group(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"codedeploy">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"codedeploy">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -443,10 +443,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_code_deploy.erl
+++ b/src/aws_code_deploy.erl
@@ -417,12 +417,8 @@ update_deployment_group(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"codedeploy">>},
-    Host = aws_util:binary_join([<<"codedeploy.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"CodeDeploy_20141006.">>/binary, Action/binary>>}],
@@ -446,3 +442,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_code_pipeline.erl
+++ b/src/aws_code_pipeline.erl
@@ -399,7 +399,7 @@ update_pipeline(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"codepipeline">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"codepipeline">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -425,10 +425,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_code_pipeline.erl
+++ b/src/aws_code_pipeline.erl
@@ -399,12 +399,8 @@ update_pipeline(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"codepipeline">>},
-    Host = aws_util:binary_join([<<"codepipeline.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"CodePipeline_20150709.">>/binary, Action/binary>>}],
@@ -428,3 +424,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_cognito.erl
+++ b/src/aws_cognito.erl
@@ -335,7 +335,7 @@ update_identity_pool(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"cognito-identity">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"cognito-identity">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -361,10 +361,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_cognito.erl
+++ b/src/aws_cognito.erl
@@ -335,12 +335,8 @@ update_identity_pool(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"cognito-identity">>},
-    Host = aws_util:binary_join([<<"cognito-identity.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"AWSCognitoIdentityService.">>/binary, Action/binary>>}],
@@ -364,3 +360,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -486,7 +486,7 @@ stop_configuration_recorder(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"config">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"config">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -512,10 +512,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_config.erl
+++ b/src/aws_config.erl
@@ -486,12 +486,8 @@ stop_configuration_recorder(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"config">>},
-    Host = aws_util:binary_join([<<"config.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"StarlingDoveService.">>/binary, Action/binary>>}],
@@ -515,3 +511,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_data_pipeline.erl
+++ b/src/aws_data_pipeline.erl
@@ -328,7 +328,7 @@ validate_pipeline_definition(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"datapipeline">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"datapipeline">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -354,10 +354,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_data_pipeline.erl
+++ b/src/aws_data_pipeline.erl
@@ -328,12 +328,8 @@ validate_pipeline_definition(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"datapipeline">>},
-    Host = aws_util:binary_join([<<"datapipeline.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"DataPipeline.">>/binary, Action/binary>>}],
@@ -357,3 +353,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_device_farm.erl
+++ b/src/aws_device_farm.erl
@@ -344,7 +344,7 @@ update_project(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"devicefarm">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"devicefarm">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -370,10 +370,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_device_farm.erl
+++ b/src/aws_device_farm.erl
@@ -344,12 +344,8 @@ update_project(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"devicefarm">>},
-    Host = aws_util:binary_join([<<"devicefarm.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"DeviceFarm_20150623.">>/binary, Action/binary>>}],
@@ -373,3 +369,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_direct_connect.erl
+++ b/src/aws_direct_connect.erl
@@ -333,7 +333,7 @@ describe_virtual_interfaces(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"directconnect">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"directconnect">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -359,10 +359,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_direct_connect.erl
+++ b/src/aws_direct_connect.erl
@@ -333,12 +333,8 @@ describe_virtual_interfaces(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"directconnect">>},
-    Host = aws_util:binary_join([<<"directconnect.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"OvertureService.">>/binary, Action/binary>>}],
@@ -362,3 +358,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_directory_service.erl
+++ b/src/aws_directory_service.erl
@@ -314,7 +314,7 @@ verify_trust(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"ds">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"ds">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -340,10 +340,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_directory_service.erl
+++ b/src/aws_directory_service.erl
@@ -314,12 +314,8 @@ verify_trust(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"ds">>},
-    Host = aws_util:binary_join([<<"ds.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"DirectoryService_20150416.">>/binary, Action/binary>>}],
@@ -343,3 +339,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_dynamodb.erl
+++ b/src/aws_dynamodb.erl
@@ -580,7 +580,7 @@ update_table(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"dynamodb">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
@@ -606,10 +606,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_dynamodb_streams.erl
+++ b/src/aws_dynamodb_streams.erl
@@ -139,7 +139,7 @@ list_streams(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"streams.dynamodb">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
@@ -165,10 +165,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_dynamodb_streams.erl
+++ b/src/aws_dynamodb_streams.erl
@@ -139,12 +139,8 @@ list_streams(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"dynamodb">>},
-    Host = aws_util:binary_join([<<"streams.dynamodb.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
                {<<"X-Amz-Target">>, << <<"DynamoDBStreams_20120810.">>/binary, Action/binary>>}],
@@ -168,3 +164,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -541,12 +541,8 @@ update_service(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"ecs">>},
-    Host = aws_util:binary_join([<<"ecs.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"AmazonEC2ContainerServiceV20141113.">>/binary, Action/binary>>}],
@@ -570,3 +566,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_ecs.erl
+++ b/src/aws_ecs.erl
@@ -541,7 +541,7 @@ update_service(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"ecs">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"ecs">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -567,10 +567,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -327,12 +327,8 @@ terminate_job_flows(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"elasticmapreduce">>},
-    Host = aws_util:binary_join([<<"elasticmapreduce.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"ElasticMapReduce.">>/binary, Action/binary>>}],
@@ -356,3 +352,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_emr.erl
+++ b/src/aws_emr.erl
@@ -327,7 +327,7 @@ terminate_job_flows(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"elasticmapreduce">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"elasticmapreduce">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -353,10 +353,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_kinesis.erl
+++ b/src/aws_kinesis.erl
@@ -616,12 +616,8 @@ split_shard(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"kinesis">>},
-    Host = aws_util:binary_join([<<"kinesis.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"Kinesis_20131202.">>/binary, Action/binary>>}],
@@ -645,3 +641,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_kinesis.erl
+++ b/src/aws_kinesis.erl
@@ -616,7 +616,7 @@ split_shard(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"kinesis">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"kinesis">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -642,10 +642,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_kms.erl
+++ b/src/aws_kms.erl
@@ -551,12 +551,8 @@ update_key_description(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"kms">>},
-    Host = aws_util:binary_join([<<"kms.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"TrentService.">>/binary, Action/binary>>}],
@@ -580,3 +576,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_kms.erl
+++ b/src/aws_kms.erl
@@ -551,7 +551,7 @@ update_key_description(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"kms">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"kms">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -577,10 +577,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_logs.erl
+++ b/src/aws_logs.erl
@@ -482,12 +482,8 @@ test_metric_filter(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"logs">>},
-    Host = aws_util:binary_join([<<"logs.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"Logs_20140328.">>/binary, Action/binary>>}],
@@ -511,3 +507,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_logs.erl
+++ b/src/aws_logs.erl
@@ -482,7 +482,7 @@ test_metric_filter(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"logs">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"logs">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -508,10 +508,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_ops_works.erl
+++ b/src/aws_ops_works.erl
@@ -1407,12 +1407,8 @@ update_volume(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"opsworks">>},
-    Host = aws_util:binary_join([<<"opsworks.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"OpsWorks_20130218.">>/binary, Action/binary>>}],
@@ -1436,3 +1432,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_ops_works.erl
+++ b/src/aws_ops_works.erl
@@ -1407,7 +1407,7 @@ update_volume(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"opsworks">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"opsworks">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -1433,10 +1433,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_route53_domains.erl
+++ b/src/aws_route53_domains.erl
@@ -318,12 +318,8 @@ update_tags_for_domain(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"route53domains">>},
-    Host = aws_util:binary_join([<<"route53domains.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"Route53Domains_v20140515.">>/binary, Action/binary>>}],
@@ -347,3 +343,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_route53_domains.erl
+++ b/src/aws_route53_domains.erl
@@ -318,7 +318,7 @@ update_tags_for_domain(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"route53domains">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"route53domains">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -344,10 +344,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_ssm.erl
+++ b/src/aws_ssm.erl
@@ -317,7 +317,7 @@ update_association_status(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"ssm">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"ssm">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -343,10 +343,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_ssm.erl
+++ b/src/aws_ssm.erl
@@ -317,12 +317,8 @@ update_association_status(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"ssm">>},
-    Host = aws_util:binary_join([<<"ssm.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"AmazonSSM.">>/binary, Action/binary>>}],
@@ -346,3 +342,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_storage_gateway.erl
+++ b/src/aws_storage_gateway.erl
@@ -979,7 +979,7 @@ update_vtl_device_type(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"storagegateway">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"storagegateway">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -1005,10 +1005,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_storage_gateway.erl
+++ b/src/aws_storage_gateway.erl
@@ -979,12 +979,8 @@ update_vtl_device_type(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"storagegateway">>},
-    Host = aws_util:binary_join([<<"storagegateway.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"StorageGateway_20130630.">>/binary, Action/binary>>}],
@@ -1008,3 +1004,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_support.erl
+++ b/src/aws_support.erl
@@ -357,7 +357,7 @@ resolve_case(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"support">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"support">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -383,10 +383,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_support.erl
+++ b/src/aws_support.erl
@@ -357,12 +357,8 @@ resolve_case(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"support">>},
-    Host = aws_util:binary_join([<<"support.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"AWSSupport_20130415.">>/binary, Action/binary>>}],
@@ -386,3 +382,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_swf.erl
+++ b/src/aws_swf.erl
@@ -1142,7 +1142,7 @@ terminate_workflow_execution(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"swf">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"swf">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
@@ -1168,10 +1168,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,

--- a/src/aws_swf.erl
+++ b/src/aws_swf.erl
@@ -1142,12 +1142,8 @@ terminate_workflow_execution(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"swf">>},
-    Host = aws_util:binary_join([<<"swf.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.0">>},
                {<<"X-Amz-Target">>, << <<"SimpleWorkflowService.">>/binary, Action/binary>>}],
@@ -1171,3 +1167,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_workspaces.erl
+++ b/src/aws_workspaces.erl
@@ -170,12 +170,8 @@ terminate_workspaces(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"workspaces">>},
-    Host = aws_util:binary_join([<<"workspaces.">>,
-                                 maps:get(region, Client1),
-                                 <<".">>,
-                                 maps:get(endpoint, Client1)],
-                                <<"">>),
-    URL = aws_util:binary_join([<<"https://">>, Host, <<"/">>], <<"">>),
+    Host = get_host(Client1),
+    URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
                {<<"X-Amz-Target">>, << <<"WorkspacesService.">>/binary, Action/binary>>}],
@@ -199,3 +195,19 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
     {error, {Exception, Reason}, {StatusCode, ResponseHeaders, Client}};
 handle_response({error, Reason}) ->
     {error, Reason}.
+
+get_host(#{region := <<"local">>}) ->
+    <<"localhost">>;
+get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
+    aws_util:binary_join([Service,
+			  <<".">>,
+			  Region,
+			  <<".">>,
+			  Endpoint],
+			 <<"">>).
+
+get_url(Host, Client) ->
+    Proto = maps:get(proto, Client),
+    Port = maps:get(port, Client),
+    aws_util:binary_join([Proto, <<"://">>, Host, <<":">>, Port, <<"/">>],
+			 <<"">>).

--- a/src/aws_workspaces.erl
+++ b/src/aws_workspaces.erl
@@ -170,7 +170,7 @@ terminate_workspaces(Client, Input, Options)
     Error :: {binary(), binary()}.
 request(Client, Action, Input, Options) ->
     Client1 = Client#{service => <<"workspaces">>},
-    Host = get_host(Client1),
+    Host = get_host(<<"workspaces">>, Client1),
     URL = get_url(Host, Client1),
     Headers = [{<<"Host">>, Host},
                {<<"Content-Type">>, <<"application/x-amz-json-1.1">>},
@@ -196,10 +196,10 @@ handle_response({ok, StatusCode, ResponseHeaders, Client}) ->
 handle_response({error, Reason}) ->
     {error, Reason}.
 
-get_host(#{region := <<"local">>}) ->
+get_host(_EndpointPrefix, #{region := <<"local">>}) ->
     <<"localhost">>;
-get_host(#{region := Region, endpoint := Endpoint, service := Service}) ->
-    aws_util:binary_join([Service,
+get_host(EndpointPrefix, #{region := Region, endpoint := Endpoint}) ->
+    aws_util:binary_join([EndpointPrefix,
 			  <<".">>,
 			  Region,
 			  <<".">>,


### PR DESCRIPTION
AWS provides a local DynamoDB for development. Requests to this dynamodb
need to be made to localhost, over unencrypted HTTP. It can be reasoned
that if AWS is to release other services for local development it will
follow a similar pattern.

This commit provides a local client that connects to localhost.