### PR TITLE
Add semver tag for versions

### DIFF
--- a/src/aws.app.src
+++ b/src/aws.app.src
@@ -1,6 +1,6 @@
 {application, aws,
  [{description, "AWS clients for Erlang."}
- ,{vsn, "0.1.0"}
+ ,{vsn, "git"}
  ,{registered, []}
  ,{applications,
     [kernel


### PR DESCRIPTION
Since the version number never changes, we can never use aws-erlang in
releases that require upgrading.